### PR TITLE
Updated configure-monitoring.sh

### DIFF
--- a/configure-monitoring.sh
+++ b/configure-monitoring.sh
@@ -83,7 +83,7 @@ echo
 echo "sudo docker run -dit \
 --restart unless-stopped \
 --log-driver loki \
---log-opt loki-url="http://LOKI-HOST-IP:3100/loki/api/v1/push" \
+--log-opt loki-url="http://$SERVER_IP:3100/loki/api/v1/push" \
 --entrypoint /usr/local/bin/keep-ecdsa \
 --volume \$KEEP_ECDSA_PERSISTENCE_DIR:/mnt/keep-ecdsa/persistence \
 --volume \$KEEP_ECDSA_KEYSTORE_DIR:/mnt/keep-ecdsa/keystore \


### PR DESCRIPTION
Why not just echo the actual server IP address into the example run command.  Makes it even easier.  Also, not sure if you want to remove the `rc.5` portion of the keep-ecdsa-client container or leave it in.  Could make a note that removing `-rc.5` would run the mainnet node.